### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   deploy:
     name: Deploy app
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/mfjt/gts.mfjt.jp/security/code-scanning/1](https://github.com/mfjt/gts.mfjt.jp/security/code-scanning/1)

To fix the problem, explicitly declare minimal permissions at either the workflow or job level. The most conservative and recommended approach is to add a `permissions` block to the job (or to the workflow root, if all jobs share the same restriction) specifying only `contents: read`. This restricts the `GITHUB_TOKEN` used in the job to read-only access to repository contents, which suffices for actions like code checkout. To implement this fix, insert the following under the affected job (after its name, before `runs-on`). Only edit within `.github/workflows/fly.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
